### PR TITLE
Add lower bound on xarray

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -7,4 +7,4 @@ channel_targets:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 python_min:
-- '3.9'
+- '3.10'

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @LucaMarconato @giovp @goanpeca
+* @LucaMarconato @giovp @goanpeca @jdblischak @melonora @thewtex

--- a/README.md
+++ b/README.md
@@ -148,4 +148,7 @@ Feedstock Maintainers
 * [@LucaMarconato](https://github.com/LucaMarconato/)
 * [@giovp](https://github.com/giovp/)
 * [@goanpeca](https://github.com/goanpeca/)
+* [@jdblischak](https://github.com/jdblischak/)
+* [@melonora](https://github.com/melonora/)
+* [@thewtex](https://github.com/thewtex/)
 

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -4,3 +4,5 @@ github:
 conda_build:
   error_overlinking: true
 conda_forge_output_validation: true
+bot:
+  inspection: update-grayskull

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -24,7 +24,7 @@ requirements:
   run:
     - numpy
     - python >={{ python_min }}
-    - xarray
+    - xarray >=2024.10.0
     - xarray-dataclass >=3.0.0
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,3 +51,4 @@ extra:
     - LucaMarconato
     - melonora
     - thewtex
+    - jdblischak


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

---

* spatial-image [1.2.3](https://github.com/spatial-image/spatial-image/releases/tag/v1.2.3) added a lower bound of `xarray >=2024.10.0` ([diff](https://github.com/spatial-image/spatial-image/compare/v1.1.0...v1.2.3#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711))
* spatial-image 1.2.3 was merged into the feedstock without adding this lower bound (https://github.com/conda-forge/spatial-image-feedstock/pull/8)
* This breaks downstream builds that run `pip check` and install older versions of xarray (https://github.com/TileDB-Inc/tiledbsoma-feedstock/issues/331)